### PR TITLE
Moping Bug Fix

### DIFF
--- a/Assets/Development/Scripts/Player/States/Player/PlayerGroundState.cs
+++ b/Assets/Development/Scripts/Player/States/Player/PlayerGroundState.cs
@@ -113,7 +113,10 @@ public class PlayerGroundState : PlayerBaseState
         else
         {
             // No interactable object hit, clear selected objects.
-            stateMachine.Hide(visualGameObject);
+            if (visualGameObject)
+            {
+                stateMachine.Hide(visualGameObject);
+            }
             stateMachine.SetSelectedStation(null);
             stateMachine.SetSelectedMess(null);
             stateMachine.SetSelectedMop(null);


### PR DESCRIPTION
Fix a bug in playerGroundState, the player was trying to access an element after it was destroyed, just added a check before calling the object