### PR TITLE
Feature/michael/carcass_cleanup

### DIFF
--- a/Assets/Development/Scripts/AI/CustomerLineQueuing.cs
+++ b/Assets/Development/Scripts/AI/CustomerLineQueuing.cs
@@ -52,6 +52,23 @@ public class CustomerLineQueuing
         }
     }
 
+    public CustomerBase RemoveFromQueue(CustomerBase customer)
+    {
+        if (customerList.Count == 0)
+            return null;
+        else
+        {
+            Debug.Log($"Thrown customer {customer.customerNumber}");
+            for (int i = 0; i < customerList.Count; i++)
+            {
+                CustomerBase customerBase = customerList[i];
+                Debug.Log($"Thrown customer index {i}");
+                customerList.RemoveAt(i);
+            }
+            return customer;
+        }
+    }
+
 
     //Moves Customer Through the line
    private void RelocateAllCustomer()

--- a/Assets/Development/Scripts/AI/CustomerManager.cs
+++ b/Assets/Development/Scripts/AI/CustomerManager.cs
@@ -45,7 +45,7 @@ public class CustomerManager : Singleton<CustomerManager>
 
     public List<CustomerBase> customersOutsideList = new List<CustomerBase>();
 
-    private CustomerLineQueuing LineQueue;
+    public CustomerLineQueuing LineQueue;
     public CustomerBarFloor barFloor;
 
     //temp stuff -> Ddog will make something more robust

--- a/Assets/Development/Scripts/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Managers/UIManager.cs
@@ -193,6 +193,16 @@ public class UIManager : Singleton<UIManager>
                     Destroy(t.gameObject);
                     return;
                 }
+                else if (o.GetOrderOwner().customerNumber == customer.customerNumber)
+                {
+                    // This exists because pickups are cloned, so the connection to the order prefab is lost
+                    Destroy(t.gameObject);
+                    return;
+                }
+                else
+                {
+                    Debug.Log($"Customer Order UI not found for {customer.customerNumber}");
+                }
             }
         }
     }

--- a/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
@@ -162,7 +162,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
                 if (baseStation != selectedStation)
                 {
                     SetSelectedStation(baseStation);
-                    //Show(visualGameObject);
+                    Show(visualGameObject);
                 }
             }
             else if (hit.transform.TryGetComponent(out Spill spill))
@@ -289,7 +289,6 @@ public class PlayerController : MonoBehaviour, IIngredientParent
     IEnumerator Dash()
     {
         float startTime = Time.time;
-        Debug.Log("dash");
 
         while (Time.time < startTime + dashTime)
         {

--- a/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
@@ -162,7 +162,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
                 if (baseStation != selectedStation)
                 {
                     SetSelectedStation(baseStation);
-                    Show(visualGameObject);
+                    //Show(visualGameObject);
                 }
             }
             else if (hit.transform.TryGetComponent(out Spill spill))
@@ -199,7 +199,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
         {
             // No interactable object hit, clear selected objects.
             SetSelectedStation(null);
-            Hide(visualGameObject);
+            //Hide(visualGameObject);
         }
 
         // Customer Interaction Logic
@@ -213,7 +213,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
                 if (customerBase != selectedCustomer)
                 {
                     SetSelectedCustomer(customerBase);
-                    Show(visualGameObject);
+                    //Show(visualGameObject);
                 }
             }
         }
@@ -221,7 +221,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
         {
             // No interactable object hit, clear selected objects.
             SetSelectedCustomer(null);
-            Hide(visualGameObject);
+            //Hide(visualGameObject);
         }
 
         Debug.DrawRay(transform.position + RayCastOffset, transform.forward, Color.green);
@@ -509,6 +509,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
         if (p.IsCustomer)
         {
             p.GetCustomer().isPickedUp = false;
+            p.GetCustomer().Dead();
         }
 
         p.transform.SetParent(null);


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/3y4v1BbG/103-bug-dead-customers-make-new-customers-hesitant-to-enter

# Description of changes
- Customer line queue needed to be updated to remove dead customers
- CustomerState.Dead
- CustomerState.Loitering
- DeadTimer() coroutine
- Disabled the debug hiding of customer heads on interact because it was conflicting with the gun shooting their heads off
- Removal of customer order UI prefab for headless and thrown customers



