### PR TITLE
CustomerBase State Refactoring, Review bug fixes

### DIFF
--- a/Assets/Development/Scripts/AI/CustomerLineQueuing.cs
+++ b/Assets/Development/Scripts/AI/CustomerLineQueuing.cs
@@ -1,20 +1,11 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
-using System;
-using System.Linq;
-
 
 public class CustomerLineQueuing
 {
     private List<Vector3> positionList;
     private List<CustomerBase> customerList;
-    //public event EventHandler OnCustomerAdded;
-    //public event EventHandler OnCustomerArrivedAtFrontOfQueue;
-    
 
-    //sorry if it seam all over the place -> no worries madood its all good
     public CustomerLineQueuing(List<Vector3> positionList)
     {
         this.positionList = positionList;
@@ -29,12 +20,9 @@ public class CustomerLineQueuing
     public void AddCustomer(CustomerBase customer)
     {
         customerList.Add(customer);
-
         customer.Walkto(positionList[customerList.IndexOf(customer)]);
-
         if(customerList.IndexOf(customer) == 0) customer.frontofLine = true;
     }
-
 
     //Gets the customer at front of queue
     public CustomerBase GetFirstInQueue()
@@ -69,7 +57,6 @@ public class CustomerLineQueuing
         }
     }
 
-
     //Moves Customer Through the line
    private void RelocateAllCustomer()
     {
@@ -78,11 +65,6 @@ public class CustomerLineQueuing
             customerList[i].Walkto(positionList[i]);
             if(i == 0) customerList[i].frontofLine = true;
         }
-    }
-
-    public void OrderTaken(CustomerBase customer)
-    {
-
     }
     
     public int GetLineCount()

--- a/Assets/Development/Scripts/AI/CustomerManager.cs
+++ b/Assets/Development/Scripts/AI/CustomerManager.cs
@@ -130,21 +130,21 @@ public class CustomerManager : Singleton<CustomerManager>
             newcustomer.SetCustomerName(customerNames[randomCustomer]);
             customerNames.RemoveAt(randomCustomer);
         }
-    
     }
+
     public int TotalCustomers()
     {
         int totalCustomers = LineQueue.GetLineCount() + barFloor.GetTotalCustomersOnFloor();
 
         return totalCustomers;
     }
+
     public int TotalMaxCapacity()
     {
         int maxCapacity = Chairs.Length + numberOfCustomers;
 
         return maxCapacity;
     }
-
 
     /* i didnt delete just incase it can be used for future code
 

--- a/Assets/Development/Scripts/AI/CustomerReview.cs
+++ b/Assets/Development/Scripts/AI/CustomerReview.cs
@@ -38,6 +38,7 @@ public class CustomerReview : MonoBehaviour
         timeToServe = GetTimeToServe();
         reviewScore = CalculateReviewScore(cafeCleanliness, cafeCrowdedness, timeToServe);
         reviewText = GenerateReviewText(reviewScore);
+        customer.StopOrderTimer();
     }
 
     private int GetCafeCleanliness()
@@ -60,8 +61,7 @@ public class CustomerReview : MonoBehaviour
 
     private float GetTimeToServe()
     {
-        timeToServe = orderOwner.orderTimer;
-        return timeToServe;
+        return orderOwner.orderTimer != null ? (float)orderOwner.orderTimer : 0;
     }
 
     private int CalculateReviewScore(int cafeCleanliness, float cafeCrowdedness, float timeToServe)

--- a/Assets/Development/Scripts/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Managers/UIManager.cs
@@ -1,9 +1,6 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
-using System;
 using TMPro;
 
 public class UIManager : Singleton<UIManager>
@@ -41,9 +38,6 @@ public class UIManager : Singleton<UIManager>
     [Header("Customer Review")]
     private CustomerReview customerReview;
     public GameObject starPrefab;
-    //public Transform starRating;
-    //public Sprite filledStarSprite;
-    //public Sprite emptyStarSprite;
 
     [Header("DebugConsole")]
     public GameObject debugConsole;
@@ -69,7 +63,6 @@ public class UIManager : Singleton<UIManager>
             closePause.onClick.AddListener(ClosePause);
         if (restartGame)
             restartGame.onClick.AddListener(RestartGame);
-
     }
     private void ReturnToGame()
     {
@@ -149,40 +142,33 @@ public class UIManager : Singleton<UIManager>
 
     public void ShowCustomerReview(CustomerBase customer)
     {
-        if (orderStats != null)
+        // This can be better by moving customer review script to the customer object
+        foreach (Transform t in ordersPanel)
         {
-            GameObject customerReviewUIObject = orderStats.GetCustomerReview(customer);
-            if (customerReviewUIObject != null)
+            OrderStats o = t.GetComponent<OrderStats>();
+            if (o != null)
             {
-                customerReview = customerReviewUIObject.GetComponentInParent<CustomerReview>();
-                if (customerReview != null)
+                if (o.GetOrderOwner() == customer)
                 {
-                    Text customerReviewText = customerReviewUIObject.GetComponent<Text>();
+                    Transform customerReviewTransform = t.gameObject.transform.Find("CustomerReview");
+                    Text customerReviewText = customerReviewTransform.gameObject.GetComponent<Text>();
+                    customerReview = customerReviewTransform.GetComponentInParent<CustomerReview>();
                     customerReview.GenerateReview(customer);
                     customerReviewText.text = customerReview.ReviewText;
                     UpdateStarRating(customerReview.ReviewScore);
-                    customerReviewUIObject.SetActive(true);
+                    customerReviewTransform.gameObject.SetActive(true);
+                    return;
                 }
                 else
                 {
-                    Debug.Log($"CustomerReview component not found on parent for {customer}");
+                    Debug.Log($"Customer Order UI not found for {customer.customerNumber}");
                 }
             }
-            else
-            {
-                Debug.LogError($"customerReviewUIObject is null for {customer}");
-            }
-        }
-        else
-        {
-            Debug.Log($"Order Stats are null for {customer}");
-            return;
         }
     }
 
     public void RemoveCustomerUiOrder(CustomerBase customer)
     {
-        // TODO: Add ingredients
         foreach (Transform t in ordersPanel)
         {
             OrderStats o = t.GetComponent<OrderStats>();
@@ -196,6 +182,7 @@ public class UIManager : Singleton<UIManager>
                 else if (o.GetOrderOwner().customerNumber == customer.customerNumber)
                 {
                     // This exists because pickups are cloned, so the connection to the order prefab is lost
+                    // Just search for the customer based on their number in case owner is lost
                     Destroy(t.gameObject);
                     return;
                 }

--- a/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/States/Player/PlayerController.cs
@@ -488,7 +488,7 @@ public class PlayerController : MonoBehaviour, IIngredientParent
         if (p.IsCustomer)
         {
             p.GetNavMeshAgent().enabled = false;
-            p.GetCustomer().isPickedUp = true;
+            p.GetCustomer().SetCustomerState(CustomerBase.CustomerState.PickedUp);
         }
 
         p.RemoveRigidBody();
@@ -507,7 +507,6 @@ public class PlayerController : MonoBehaviour, IIngredientParent
 
         if (p.IsCustomer)
         {
-            p.GetCustomer().isPickedUp = false;
             p.GetCustomer().Dead();
         }
 

--- a/Assets/Development/Scripts/UI/OrderStats.cs
+++ b/Assets/Development/Scripts/UI/OrderStats.cs
@@ -33,19 +33,4 @@ public class OrderStats : MonoBehaviour
         spicinessSlider.value = customer.coffeeAttributes.GetSpiciness() * .10f;
         customerNumberText.text = customer.customerNumber.ToString();
     }
-
-    // Return the customer review object to UIManager so that it can be enabled
-    public GameObject GetCustomerReview(CustomerBase customer)
-    {
-        OrderStats[] allOrderStats = Object.FindObjectsOfType<OrderStats>();
-        foreach (OrderStats orderStats in allOrderStats)
-        {
-            if (orderStats.orderOwner.GetInstanceID() == customer.GetInstanceID())
-            {
-                customerReview = orderStats.customerReview;
-                return customerReview;
-            }
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
CustomerBase state refactoring and inconsistent review bug issues.  The idea is customer state changes accommodate all things that should happen.  For example, if a customer is ordering, everything that needs to happen is triggered by changing the state to ordering.  Some methods still need to be figured out, some states were never implemented so they were noted in case we want to remove them later.

# Related board task URL
https://trello.com/c/YmEXlTvA/211-feature-customerbaseupdate-review-updates
https://trello.com/c/Q0k0EXdC/175-bug-second-customer-review-never-appears-but-1st-and-3rd-does
https://trello.com/c/6cAoDTs8/80-bug-customerreorder-breaks-review-scores

# Description of changes
Goal was to control the customer based on state as much as possible due to consistency issues in network play.

Example: Instead of invoking Leaving() with a delay on Order(), when the customer is in "InSit" state, it checks if their timer threshold has been met and eventually changes to "Leaving" state

- Changed Update() to only contain a switch for state
- Created Update<action>() for each state change
- Removed dead "Usings"
- Fixed bug where customer review doesn't appear
- Removed the need for GetCustomerReview() from orderstats

# Related notes
- None

