### PR TITLE
Updated order UI to show cumulative and potential

### DIFF
--- a/Assets/Development/Scripts/Environment/Stations/BrewingStation.cs
+++ b/Assets/Development/Scripts/Environment/Stations/BrewingStation.cs
@@ -7,6 +7,8 @@ using Unity.Netcode;
 
 public class BrewingStation : BaseStation, IHasProgress, IHasMinigameTiming
 {
+    public Transform orderStatsRoot;
+    
     public event EventHandler<IHasProgress.OnProgressChangedEventArgs> OnProgressChanged;
     public event EventHandler<IHasMinigameTiming.OnMinigameTimingEventArgs> OnMinigameTimingStarted;
 
@@ -132,6 +134,21 @@ public class BrewingStation : BaseStation, IHasProgress, IHasMinigameTiming
                     Ingredient.DestroyIngredient(ingredient);
 
                     InteractLogicPlaceObjectOnBrewingServerRpc();
+
+                    if (orderStatsRoot.childCount > 0)
+                    {
+                        OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                        
+                        orderStats.temperatureSegments.cumulativeIngredientsValue += ingredient.IngredientSO.temperature;
+                        orderStats.sweetnessSegments.cumulativeIngredientsValue += ingredient.IngredientSO.sweetness;
+                        orderStats.spicinessSegments.cumulativeIngredientsValue += ingredient.IngredientSO.spiciness;
+                        orderStats.strengthSegments.cumulativeIngredientsValue += ingredient.IngredientSO.strength;
+
+                        orderStats.temperatureSegments.potentialIngredientValue = 0;
+                        orderStats.sweetnessSegments.potentialIngredientValue = 0;
+                        orderStats.spicinessSegments.potentialIngredientValue = 0;
+                        orderStats.strengthSegments.potentialIngredientValue = 0;
+                    }
                 }
             }
             /*if (player.GetNumberOfIngredients() >= 1)

--- a/Assets/Development/Scripts/Multiplayer/Network/BaristapocalypseMultiplayer.cs
+++ b/Assets/Development/Scripts/Multiplayer/Network/BaristapocalypseMultiplayer.cs
@@ -39,6 +39,9 @@ public class BaristapocalypseMultiplayer : NetworkBehaviour
 
     public int GetIngredientSOIndex(IngredientSO ingredientSO)
     {
+        Debug.Log(ingredientSO.sweetness);
+        int i = ingredientListSO.ingredientSOList.IndexOf(ingredientSO);
+        Debug.Log(ingredientListSO.ingredientSOList[i].sweetness);
         return ingredientListSO.ingredientSOList.IndexOf(ingredientSO);
     }
 

--- a/Assets/Development/Scripts/UI/IngredientSelectionUI.cs
+++ b/Assets/Development/Scripts/UI/IngredientSelectionUI.cs
@@ -8,6 +8,9 @@ public class IngredientSelectionUI : BaseStation
 {
     private PlayerController player;
 
+    public Transform orderStatsRoot;
+    private bool currentStationInteraction;
+
     [SerializeField] private GameObject ingredientMenu;
     private string hoverButtonName;
 
@@ -32,6 +35,10 @@ public class IngredientSelectionUI : BaseStation
 
     private void Update()
     {
+        if (!currentStationInteraction)
+            return;
+
+        Debug.Log(name);
         // Detect the name of the button that the cursor is hovering over
         PointerEventData pointerEventData = new PointerEventData(EventSystem.current);
         pointerEventData.position = Input.mousePosition;
@@ -54,36 +61,107 @@ public class IngredientSelectionUI : BaseStation
             ingredientListSOIndex = 0;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+                Debug.LogError(currentIngredient.temperature);
+                Debug.LogError(currentIngredient.sweetness);
+                Debug.LogError(currentIngredient.spiciness);
+                Debug.LogError(currentIngredient.strength);
+                Debug.LogError("this", ingredientListSO[ingredientListSOIndex]);
+            }
         }
-        if (hoverButtonName == "CosmicCacao" || hoverButtonName == "Water" || hoverButtonName == "MoonMaple" || hoverButtonName == "ButterBugs")
+        else if (hoverButtonName == "CosmicCacao" || hoverButtonName == "Water" || hoverButtonName == "MoonMaple" || hoverButtonName == "ButterBugs")
         {
             ingredientListSOIndex = 1;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+            }
         }
-        if (hoverButtonName == "Excelsior" || hoverButtonName == "BlueMilk" || hoverButtonName == "GalaxyGummy" || hoverButtonName == "Brains")
+        else if (hoverButtonName == "Excelsior" || hoverButtonName == "BlueMilk" || hoverButtonName == "GalaxyGummy" || hoverButtonName == "Brains")
         {
             ingredientListSOIndex = 2;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+            }
         }
-        if (hoverButtonName == "Robusta" || hoverButtonName == "Moonshine" || hoverButtonName == "MochaMiel" || hoverButtonName == "FunkyFungus")
+        else if (hoverButtonName == "Robusta" || hoverButtonName == "Moonshine" || hoverButtonName == "MochaMiel" || hoverButtonName == "FunkyFungus")
         {
             ingredientListSOIndex = 3;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+            }
         }
-        if (hoverButtonName == "KopiLuwak" || hoverButtonName == "LavaGuava" || hoverButtonName == "Molasses" || hoverButtonName == "JupiterJelly")
+        else if (hoverButtonName == "KopiLuwak" || hoverButtonName == "LavaGuava" || hoverButtonName == "Molasses" || hoverButtonName == "JupiterJelly")
         {
             ingredientListSOIndex = 4;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+            }
         }
-        if (hoverButtonName == "Undefined" || hoverButtonName == "Gobstopper" || hoverButtonName == "MeatCube")
+        else if (hoverButtonName == "Undefined" || hoverButtonName == "Gobstopper" || hoverButtonName == "MeatCube")
         {
             ingredientListSOIndex = 5;
             currentIngredient = ingredientListSO[ingredientListSOIndex];
             Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
+
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = currentIngredient.temperature;
+                orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness;
+                orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness;
+                orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength;
+            }
+        }
+        else
+        {
+            if (orderStatsRoot != null && orderStatsRoot.childCount > 0)
+            {
+                OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
+                orderStats.temperatureSegments.potentialIngredientValue = 0;
+                orderStats.sweetnessSegments.potentialIngredientValue = 0;
+                orderStats.spicinessSegments.potentialIngredientValue = 0;
+                orderStats.strengthSegments.potentialIngredientValue = 0;
+                Debug.LogError("whatever");
+            }
         }
 
         // TODO - On cursor hover change slider values based on the ingredient
@@ -154,6 +232,7 @@ public class IngredientSelectionUI : BaseStation
 
     private void Show(GameObject obj)
     {
+        currentStationInteraction = true;
         obj.SetActive(true);
     }
 
@@ -162,5 +241,6 @@ public class IngredientSelectionUI : BaseStation
         ingredientMenu.GetComponent<Animator>().Play("Ingredient_UI_Shrink");
         yield return new WaitForSeconds(0.5f);
         Hide(ingredientMenu);
+        currentStationInteraction = false;
     }
 }

--- a/Assets/Development/Scripts/UI/OrderStats.cs
+++ b/Assets/Development/Scripts/UI/OrderStats.cs
@@ -7,10 +7,10 @@ public class OrderStats : MonoBehaviour
 {
     [Header("Customer Order")]
     [SerializeField] private Text customerNumberText;
-    [SerializeField] private OrderStatsSegments temperatureSegments;
-    [SerializeField] private OrderStatsSegments sweetnessSegments;
-    [SerializeField] private OrderStatsSegments spicinessSegments;
-    [SerializeField] private OrderStatsSegments strengthSegments;
+    [SerializeField] public OrderStatsSegments temperatureSegments;
+    [SerializeField] public OrderStatsSegments sweetnessSegments;
+    [SerializeField] public OrderStatsSegments spicinessSegments;
+    [SerializeField] public OrderStatsSegments strengthSegments;
     
     [Header("Customer Review")]
     [SerializeField] private GameObject customerReview;

--- a/Assets/Development/Scripts/UI/OrderStatsSegments.cs
+++ b/Assets/Development/Scripts/UI/OrderStatsSegments.cs
@@ -50,6 +50,23 @@ public class OrderStatsSegments : MonoBehaviour
                 segments[(segments.Length / 2) + targetAttributeValue].GetComponent<Image>().color = Color.green;
             if (targetAttributeValue > 0 && cumulative != targetAttributeValue)
                 segments[(segments.Length / 2 - 1) + targetAttributeValue].GetComponent<Image>().color = Color.green;
+            int startIndex = segments.Length / 2 - 1;
+            int endIndex = startIndex + cumulative;
+            if (potentialIngredientValue < 0)
+            {
+                for (int i = endIndex; i > endIndex + potentialIngredientValue; i--)
+                {
+                    segments[i].GetComponent<Image>().color = Color.red;
+                }
+            }
+
+            if (potentialIngredientValue > 0)
+            {
+                for (int i = endIndex; i < endIndex + potentialIngredientValue; i++)
+                {
+                    segments[i].GetComponent<Image>().color = Color.red;
+                }
+            }
             return;
         }
 

--- a/Assets/Scenes/MasterScenes/T5M3_BUILD.unity
+++ b/Assets/Scenes/MasterScenes/T5M3_BUILD.unity
@@ -10469,6 +10469,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6828886579067854174, guid: ef4537bb3b3fc734089c5851a8648206, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 566575929}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef4537bb3b3fc734089c5851a8648206, type: 3}
 --- !u!1 &439775202
@@ -28480,107 +28484,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1001 &1035643386
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 566575929}
-    m_Modifications:
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 534672930084279481, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5308759679528095304, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_Name
-      value: OrderStats
-      objectReference: {fileID: 0}
-    - target: {fileID: 5308759679528095304, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
 --- !u!1 &1036085237
 GameObject:
   m_ObjectHideFlags: 0
@@ -35268,6 +35171,10 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1550134252994797648, guid: bbc6ae028c642f84b90d03e82a1440fd, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 566575929}
     - target: {fileID: 1550134253072834324, guid: bbc6ae028c642f84b90d03e82a1440fd, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -39994,6 +39901,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LiquidStation
       objectReference: {fileID: 0}
+    - target: {fileID: 5314870874340927408, guid: 451370859b2a27c4fba09593a691ed65, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 566575929}
     - target: {fileID: 6214337049162921883, guid: 451370859b2a27c4fba09593a691ed65, type: 3}
       propertyPath: m_RootOrder
       value: 4
@@ -44107,6 +44018,10 @@ PrefabInstance:
       propertyPath: GlobalObjectIdHash
       value: 101131419
       objectReference: {fileID: 0}
+    - target: {fileID: 3940924465353773210, guid: 362d13b06f9add647a5fb8184705949f, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 566575929}
     - target: {fileID: 5080327576041297807, guid: 362d13b06f9add647a5fb8184705949f, type: 3}
       propertyPath: m_Name
       value: SweetenerStation
@@ -46968,6 +46883,10 @@ PrefabInstance:
       propertyPath: m_PresetInfoIsWorld
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4448117747942318682, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 566575929}
     - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: m_RootOrder
       value: 3


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/WawRjZTL/325-order-slider-stats-ui

# Description of changes
- Fixed bug where values from selected ingredient come from incorrect station
- Updated cumulative drink values based on what is in brewing station
- Updated potential drink values based on what is hovered / selected

# Related notes
- Only works with one brewing station.  Discussions still happening if multiple stations will be in game
- One drink at a time as discussed, may change later

