### PR TITLE
Multiple Brewing Stations and bug fixes

### DIFF
--- a/Assets/Development/Prefabs/Customers/Customer Sample.prefab
+++ b/Assets/Development/Prefabs/Customers/Customer Sample.prefab
@@ -1124,6 +1124,7 @@ Transform:
   - {fileID: 8890427119754575853}
   - {fileID: 8028185746511386370}
   - {fileID: 4961381447448103050}
+  - {fileID: 652586481719592064}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1204,6 +1205,7 @@ MonoBehaviour:
   - {fileID: 673274661197347126}
   - {fileID: 2085907929542913488}
   - {fileID: 49536424708501832}
+  cheatIconsLayoutGroup: {fileID: 1460613503856776164}
   temperature:
   - {fileID: 11400000, guid: 67ec6e36fb22a934f8f08ed2d2d2a3bd, type: 2}
   - {fileID: 11400000, guid: ea4fdd638cf7f7440a67f48c87a0d5fa, type: 2}
@@ -1414,6 +1416,76 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6523125881497465146
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 652586481719592064}
+  - component: {fileID: 1460613503856776164}
+  - component: {fileID: 3155098453594227082}
+  m_Layer: 10
+  m_Name: Cheat Icons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &652586481719592064
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6523125881497465146}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: -0.089999914}
+  m_LocalScale: {x: 0.074152514, y: 0.074152514, z: 0.074152514}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5640675751676341536}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.01999998, y: 6.29}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1460613503856776164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6523125881497465146}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 100, y: 100}
+  m_Spacing: {x: 0, y: 0}
+  m_Constraint: 0
+  m_ConstraintCount: 2
+--- !u!222 &3155098453594227082
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6523125881497465146}
+  m_CullTransparentMesh: 1
 --- !u!1 &8571327297907685429
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Development/Prefabs/Stations/BrewingStation.prefab
+++ b/Assets/Development/Prefabs/Stations/BrewingStation.prefab
@@ -521,7 +521,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2305830337154933689, guid: a1a86f6dec8a4f547be4f92cb7a6b2c3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.65
+      value: -0.281
       objectReference: {fileID: 0}
     - target: {fileID: 2305830337154933689, guid: a1a86f6dec8a4f547be4f92cb7a6b2c3, type: 3}
       propertyPath: m_LocalPosition.z
@@ -565,7 +565,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8083973324504194466, guid: a1a86f6dec8a4f547be4f92cb7a6b2c3, type: 3}
       propertyPath: m_Name
-      value: BrewingStation
+      value: BrewingStation 1
       objectReference: {fileID: 0}
     - target: {fileID: 8280110119343447755, guid: a1a86f6dec8a4f547be4f92cb7a6b2c3, type: 3}
       propertyPath: m_Enabled
@@ -596,12 +596,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   stationTopPoint: {fileID: 5328838951665215557}
-  orderStatsRoot: {fileID: 0}
-  ingredientSOList: []
   interactParticle: {fileID: 3823761264207694108}
-  ingredientsIndicatorText: {fileID: 220367961}
+  orderStatsRoot: {fileID: 0}
+  orderStatsPrefab: {fileID: 5308759679528095304, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
   orderStats: {fileID: 6946990445526301406, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
+  customer: {fileID: 0}
+  ingredientSOList: []
+  ingredientsIndicatorText: {fileID: 220367961}
+  currentIngredientSOList: 
+  validIngredientTagList: []
+  numIngredientsNeeded: 4
   brewingRecipeSO: {fileID: 11400000, guid: 51673626c59b856478165b70a83edda2, type: 2}
+  orderAssigned: 0
 --- !u!198 &3823761264207694108 stripped
 ParticleSystem:
   m_CorrespondingSourceObject: {fileID: 6545181316283945739, guid: a1a86f6dec8a4f547be4f92cb7a6b2c3, type: 3}

--- a/Assets/Development/Prefabs/Stations/Environment/Sink.prefab
+++ b/Assets/Development/Prefabs/Stations/Environment/Sink.prefab
@@ -6105,7 +6105,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 5149995174780877541}
   m_FillRect: {fileID: 5149995174625229784}
   m_HandleRect: {fileID: 5149995174780877538}

--- a/Assets/Development/Prefabs/UI/OrderStats.prefab
+++ b/Assets/Development/Prefabs/UI/OrderStats.prefab
@@ -45,6 +45,7 @@ RectTransform:
   - {fileID: 4518976879051590712}
   - {fileID: 5895919048961321616}
   - {fileID: 6083684254219983272}
+  - {fileID: 3100173189314164762}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -130,6 +131,7 @@ RectTransform:
   - {fileID: 7232871490892061836}
   - {fileID: 8011172187998441118}
   - {fileID: 1273864729134532903}
+  - {fileID: 4645109774384473226}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -215,6 +217,7 @@ RectTransform:
   - {fileID: 3370321312073079373}
   - {fileID: 8576410754717313650}
   - {fileID: 534625736545857630}
+  - {fileID: 4406535742348379616}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -520,6 +523,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &329164204012806128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3100173189314164762}
+  - component: {fileID: 1456043452585893927}
+  - component: {fileID: 6579734397472413833}
+  m_Layer: 5
+  m_Name: Panel (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3100173189314164762
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 329164204012806128}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 740841140}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4.6, y: -21.4}
+  m_SizeDelta: {x: -112.618, y: -7.047}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1456043452585893927
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 329164204012806128}
+  m_CullTransparentMesh: 1
+--- !u!114 &6579734397472413833
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 329164204012806128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &392206714288760234
 GameObject:
   m_ObjectHideFlags: 0
@@ -748,6 +827,43 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &603634255964231260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8580314825706743934}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8580314825706743934
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 603634255964231260}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3229349914117783071}
+  m_Father: {fileID: 8171810364724800867}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &728491947982470620
 GameObject:
   m_ObjectHideFlags: 0
@@ -1113,6 +1229,86 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &968210667438408071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5579936685854780131}
+  - component: {fileID: 7972553507686146630}
+  - component: {fileID: 8099295033166711158}
+  m_Layer: 5
+  m_Name: BrewingStation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5579936685854780131
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968210667438408071}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6624607922918798186}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -4.8, y: 0}
+  m_SizeDelta: {x: 178.732, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7972553507686146630
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968210667438408071}
+  m_CullTransparentMesh: 1
+--- !u!114 &8099295033166711158
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968210667438408071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Brewing Station #
 --- !u!1 &1007622606382086954
 GameObject:
   m_ObjectHideFlags: 0
@@ -1675,6 +1871,82 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &1439252423957366753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3229349914117783071}
+  - component: {fileID: 5714687797930153473}
+  - component: {fileID: 7979331744859591036}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3229349914117783071
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1439252423957366753}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8580314825706743934}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5714687797930153473
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1439252423957366753}
+  m_CullTransparentMesh: 1
+--- !u!114 &7979331744859591036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1439252423957366753}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.7803922, g: 0.4784314, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1581936926933888490
 GameObject:
   m_ObjectHideFlags: 0
@@ -2092,6 +2364,82 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1869377979312932598
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6694239584540371896}
+  - component: {fileID: 3344937536543616250}
+  - component: {fileID: 8411015376156206639}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6694239584540371896
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869377979312932598}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8171810364724800867}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3344937536543616250
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869377979312932598}
+  m_CullTransparentMesh: 1
+--- !u!114 &8411015376156206639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1869377979312932598}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8773585, g: 0.086908154, b: 0.086908154, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1875900185650310933
 GameObject:
   m_ObjectHideFlags: 0
@@ -2259,6 +2607,97 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2036749707314613631
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8171810364724800867}
+  - component: {fileID: 787622165116171192}
+  m_Layer: 5
+  m_Name: Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8171810364724800867
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036749707314613631}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6694239584540371896}
+  - {fileID: 8042313089670174759}
+  - {fileID: 8580314825706743934}
+  m_Father: {fileID: 3766708366540476843}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.732, y: 0}
+  m_SizeDelta: {x: 75.435, y: 160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &787622165116171192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2036749707314613631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 7979331744859591036}
+  m_FillRect: {fileID: 4107746437553438840}
+  m_HandleRect: {fileID: 3229349914117783071}
+  m_Direction: 2
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &2091503589095083055
 GameObject:
   m_ObjectHideFlags: 0
@@ -2644,6 +3083,43 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2480677447632253173
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8042313089670174759}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8042313089670174759
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2480677447632253173}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4107746437553438840}
+  m_Father: {fileID: 8171810364724800867}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0}
+  m_AnchorMax: {x: 0.75, y: 1}
+  m_AnchoredPosition: {x: 0, y: -5}
+  m_SizeDelta: {x: 0, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2521537285958259852
 GameObject:
   m_ObjectHideFlags: 0
@@ -2808,12 +3284,12 @@ GameObject:
   - component: {fileID: 2860970958868935430}
   - component: {fileID: 8500277593446558680}
   m_Layer: 5
-  m_Name: Image
+  m_Name: CustomerInfoRoot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6624607922918798186
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2828,6 +3304,8 @@ RectTransform:
   m_Children:
   - {fileID: 3982932395686797212}
   - {fileID: 7560482592745133254}
+  - {fileID: 5579936685854780131}
+  - {fileID: 3766708366540476843}
   m_Father: {fileID: 534672930084279481}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3565,6 +4043,7 @@ RectTransform:
   - {fileID: 2863865073735846810}
   - {fileID: 7122381211176224173}
   - {fileID: 5148611151064893460}
+  - {fileID: 7042336761777355441}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5066,15 +5545,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3f47a28645d14a4982961ab155c1c29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  customerInfoRoot: {fileID: 2559236773826034335}
   customerNumberText: {fileID: 7105744732798287007}
-  orderResponsibilityText: {fileID: 5700476278152472598}
+  customerNameText: {fileID: 5700476278152472598}
+  brewingStationText: {fileID: 8099295033166711158}
+  orderTimer: {fileID: 787622165116171192}
   temperatureSegments: {fileID: 344461229118731872}
   sweetnessSegments: {fileID: 1783268524}
   spicinessSegments: {fileID: 783548760}
   strengthSegments: {fileID: 740841141}
   customerReview: {fileID: 2207627189283486580}
   orderOwner: {fileID: 0}
-  orderResponsibility: {fileID: 0}
 --- !u!114 &8493857899964159927
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5383,6 +5864,82 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5629998828190811144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5729168716121379239
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4645109774384473226}
+  - component: {fileID: 4897753799450517456}
+  - component: {fileID: 6946697655685975492}
+  m_Layer: 5
+  m_Name: Panel (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4645109774384473226
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729168716121379239}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 783548759}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4.6, y: -11}
+  m_SizeDelta: {x: -112.618, y: -7.047}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4897753799450517456
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729168716121379239}
+  m_CullTransparentMesh: 1
+--- !u!114 &6946697655685975492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5729168716121379239}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -6801,7 +7358,7 @@ GameObject:
   - component: {fileID: 9139136829785281663}
   - component: {fileID: 5700476278152472598}
   m_Layer: 5
-  m_Name: OrderResponsibility
+  m_Name: CustomerName
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6824,8 +7381,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_AnchoredPosition: {x: -4.8, y: 21.923}
+  m_SizeDelta: {x: 178.73, y: 21.353}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &9139136829785281663
 CanvasRenderer:
@@ -6862,13 +7419,13 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 10
     m_MaxSize: 40
-    m_Alignment: 0
+    m_Alignment: 1
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: 'Owner: '
+  m_Text: Customer Name
 --- !u!1 &7475317094675003605
 GameObject:
   m_ObjectHideFlags: 0
@@ -6936,6 +7493,82 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7598263353359423296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4107746437553438840}
+  - component: {fileID: 9193391516181615877}
+  - component: {fileID: 2810571231479635772}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4107746437553438840
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7598263353359423296}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8042313089670174759}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9193391516181615877
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7598263353359423296}
+  m_CullTransparentMesh: 1
+--- !u!114 &2810571231479635772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7598263353359423296}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8113208, g: 0.4975941, b: 0.019134922, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -7283,6 +7916,82 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7919793802846979939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7962793638554397250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4406535742348379616}
+  - component: {fileID: 5686623912845641140}
+  - component: {fileID: 6668738342266684292}
+  m_Layer: 5
+  m_Name: Panel (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4406535742348379616
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7962793638554397250}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1783268523}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4.6, y: -1.5}
+  m_SizeDelta: {x: -112.618, y: -7.047}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5686623912845641140
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7962793638554397250}
+  m_CullTransparentMesh: 1
+--- !u!114 &6668738342266684292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7962793638554397250}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -7762,6 +8471,82 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8474052256413928557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7042336761777355441}
+  - component: {fileID: 2902435495915516405}
+  - component: {fileID: 1673455682971013943}
+  m_Layer: 5
+  m_Name: Panel (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7042336761777355441
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8474052256413928557}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7310803891986885742}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -4.6, y: 7.454}
+  m_SizeDelta: {x: -112.618, y: -7.047}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2902435495915516405
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8474052256413928557}
+  m_CullTransparentMesh: 1
+--- !u!114 &1673455682971013943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8474052256413928557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8636471795681498552
 GameObject:
   m_ObjectHideFlags: 0
@@ -8027,3 +8812,40 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8776188033332383177
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3766708366540476843}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3766708366540476843
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8776188033332383177}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0.009324003}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8171810364724800867}
+  m_Father: {fileID: 6624607922918798186}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -167.20003, y: -115.90002}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Development/Prefabs/UI/OrderStats.prefab
+++ b/Assets/Development/Prefabs/UI/OrderStats.prefab
@@ -36,6 +36,7 @@ RectTransform:
   - {fileID: 5389193974398953388}
   - {fileID: 1462211357064192217}
   - {fileID: 7622113538362749532}
+  - {fileID: 3100173189314164762}
   - {fileID: 2873847431231433918}
   - {fileID: 318731983213681749}
   - {fileID: 5098499331730213443}
@@ -45,7 +46,6 @@ RectTransform:
   - {fileID: 4518976879051590712}
   - {fileID: 5895919048961321616}
   - {fileID: 6083684254219983272}
-  - {fileID: 3100173189314164762}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -74,6 +74,7 @@ MonoBehaviour:
   - {fileID: 2521537285958259852}
   - {fileID: 5747768251584939401}
   - {fileID: 3830288107770483299}
+  - {fileID: 329164204012806128}
   - {fileID: 3731584161491801304}
   - {fileID: 2412270642544585354}
   - {fileID: 3868964323910009103}
@@ -122,6 +123,7 @@ RectTransform:
   - {fileID: 6843547986103593120}
   - {fileID: 8540939369046123698}
   - {fileID: 8994494656776186170}
+  - {fileID: 4645109774384473226}
   - {fileID: 1527472678657373636}
   - {fileID: 5762881258645648370}
   - {fileID: 6548557284065982724}
@@ -131,7 +133,6 @@ RectTransform:
   - {fileID: 7232871490892061836}
   - {fileID: 8011172187998441118}
   - {fileID: 1273864729134532903}
-  - {fileID: 4645109774384473226}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -160,6 +161,7 @@ MonoBehaviour:
   - {fileID: 6123602246448994919}
   - {fileID: 4445277458564462760}
   - {fileID: 1775165944026290496}
+  - {fileID: 5729168716121379239}
   - {fileID: 8636471795681498552}
   - {fileID: 5414484731252438774}
   - {fileID: 7146280241415785051}
@@ -208,6 +210,7 @@ RectTransform:
   - {fileID: 1463091323931760971}
   - {fileID: 6348845148968160934}
   - {fileID: 2805419520353332748}
+  - {fileID: 4406535742348379616}
   - {fileID: 6044723730534416970}
   - {fileID: 6084571632046919445}
   - {fileID: 3591512098370145517}
@@ -217,7 +220,6 @@ RectTransform:
   - {fileID: 3370321312073079373}
   - {fileID: 8576410754717313650}
   - {fileID: 534625736545857630}
-  - {fileID: 4406535742348379616}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -246,6 +248,7 @@ MonoBehaviour:
   - {fileID: 5136527301989948016}
   - {fileID: 7052391068413731163}
   - {fileID: 1691953596387513699}
+  - {fileID: 7962793638554397250}
   - {fileID: 8681826517810178674}
   - {fileID: 6819733305956873663}
   - {fileID: 244026604912791204}
@@ -326,7 +329,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -402,7 +405,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -548,14 +551,14 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 329164204012806128}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -4.6, y: -21.4}
@@ -630,7 +633,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -706,7 +709,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1340,7 +1343,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1507,7 +1510,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1659,7 +1662,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 16
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1735,7 +1738,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.25}
   m_AnchorMax: {x: 0, y: 0.25}
@@ -2729,7 +2732,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3038,7 +3041,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3227,7 +3230,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3611,7 +3614,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3800,7 +3803,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3876,7 +3879,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3952,7 +3955,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4033,6 +4036,7 @@ RectTransform:
   - {fileID: 4104591658816334150}
   - {fileID: 2056928082235379292}
   - {fileID: 8617473967033026940}
+  - {fileID: 7042336761777355441}
   - {fileID: 2926981877149194477}
   - {fileID: 3049774517204677132}
   - {fileID: 3185576443289402871}
@@ -4043,7 +4047,6 @@ RectTransform:
   - {fileID: 2863865073735846810}
   - {fileID: 7122381211176224173}
   - {fileID: 5148611151064893460}
-  - {fileID: 7042336761777355441}
   m_Father: {fileID: 4573838450599542120}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4072,6 +4075,7 @@ MonoBehaviour:
   - {fileID: 7047972911128263069}
   - {fileID: 2255419659635476192}
   - {fileID: 2947150017583026512}
+  - {fileID: 8474052256413928557}
   - {fileID: 217143009004144509}
   - {fileID: 5255351967265762005}
   - {fileID: 8173107492588859246}
@@ -4347,7 +4351,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4649,7 +4653,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4990,7 +4994,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5179,7 +5183,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5331,7 +5335,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5407,7 +5411,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5690,7 +5694,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5766,7 +5770,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5842,7 +5846,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -5912,14 +5916,14 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5729168716121379239}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -4.6, y: -11}
@@ -6298,7 +6302,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 14
+  m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6541,7 +6545,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6769,7 +6773,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6845,7 +6849,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 13
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7073,7 +7077,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7149,7 +7153,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7457,7 +7461,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7964,14 +7968,14 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7962793638554397250}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -4.6, y: -1.5}
@@ -8122,7 +8126,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8198,7 +8202,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 740841140}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8426,7 +8430,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -8496,14 +8500,14 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8474052256413928557}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7310803891986885742}
-  m_RootOrder: 17
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -4.6, y: 7.454}
@@ -8578,7 +8582,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8654,7 +8658,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1783268523}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8767,7 +8771,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 783548759}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -258,7 +258,10 @@ public class CustomerBase : Base
             foreach (BrewingStation brewingStation in brewingStations)
             {
                 if (!brewingStation.orderAssigned)
+                {
                     brewingStation.SetOrder(this);
+                    break;
+                }
                 else
                     Debug.Log("Brewing station is busy"); // this should add an element to the order queue ui that is not done yet
             }

--- a/Assets/Development/Scripts/AI/CustomerManager.cs
+++ b/Assets/Development/Scripts/AI/CustomerManager.cs
@@ -194,7 +194,6 @@ public class CustomerManager : Singleton<CustomerManager>
 
     public void Leaveline()
     {
-        Debug.Log("hiii");
         CustomerBase customer = LineQueue.GetFirstInQueue();
         barFloor.TrySendToChair(customer);
         customer.inLine = false;

--- a/Assets/Development/Scripts/AI/CustomerRandomizer.cs
+++ b/Assets/Development/Scripts/AI/CustomerRandomizer.cs
@@ -2,13 +2,16 @@ using JetBrains.Annotations;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Netcode;
+using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class CustomerRandomizer : NetworkBehaviour
 {
     [SerializeField] public CustomerRaceSO[] Races;
     public List<GameObject> heads = new List<GameObject>();
     public List<GameObject> bodies = new List<GameObject>();
+    public GridLayoutGroup cheatIconsLayoutGroup;
 
     public List<IngredientSO> temperature = new List<IngredientSO>();
     public List<IngredientSO> sweetness = new List<IngredientSO>();
@@ -36,6 +39,16 @@ public class CustomerRandomizer : NetworkBehaviour
         IngredientSO sweetnessIngredient = sweetness[Random.Range(0, sweetness.Count)];
         IngredientSO strenthIngredient = strength[Random.Range(0, strength.Count)];
         IngredientSO spicinessIngredient = spiciness[Random.Range(0, spiciness.Count)];
+
+        //temperatureIngredient.icon.transform.SetParent(cheatIconsLayoutGroup.transform);
+        //sweetnessIngredient.icon.transform.SetParent(cheatIconsLayoutGroup.transform);
+        //strenthIngredient.icon.transform.SetParent(cheatIconsLayoutGroup.transform);
+        //spicinessIngredient.icon.transform.SetParent(cheatIconsLayoutGroup.transform);
+        
+        Debug.Log("ISO Temperature: " + temperatureIngredient.name);
+        Debug.Log("ISO Sweetness: " + sweetnessIngredient.name);
+        Debug.Log("ISO Strength: " + strenthIngredient.name);
+        Debug.Log("ISO Spiciness: " + spicinessIngredient.name);
 
         // DELETE AFTER TESTING //
         sweet = sweetnessIngredient;

--- a/Assets/Development/Scripts/Environment/Ingredients/IngredientSO.cs
+++ b/Assets/Development/Scripts/Environment/Ingredients/IngredientSO.cs
@@ -1,6 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 [CreateAssetMenu()]
 public class IngredientSO : ScriptableObject
@@ -12,4 +11,5 @@ public class IngredientSO : ScriptableObject
     public int sweetness;
     public int spiciness;
     public int strength;
+    //public Image icon;
 }

--- a/Assets/Development/Scripts/Environment/Physics/BlackHole.cs
+++ b/Assets/Development/Scripts/Environment/Physics/BlackHole.cs
@@ -25,7 +25,6 @@ public class BlackHole : MonoBehaviour
 
     private void ApplyBlackHoleEffect(Rigidbody targetRigidbody)
     {
-        Debug.Log("In the blackhole");
         targetRigidbody.useGravity = false;
         Vector3 directionToCenter = transform.position - targetRigidbody.position;
         float distance = Vector3.Distance(transform.position, targetRigidbody.position);

--- a/Assets/Development/Scripts/Environment/Stations/BrewingStation.cs
+++ b/Assets/Development/Scripts/Environment/Stations/BrewingStation.cs
@@ -92,15 +92,53 @@ public class BrewingStation : BaseStation, IHasProgress, IHasMinigameTiming
                 sweetSpotPosition = sweetSpotPosition
             });
         }
+
+        if (orderAssigned)
+        {
+            orderStats.SetInactive(false);
+            orderStats.orderTimer.value = (customer.customerLeaveTime - customer.orderTimer.Value) / customer.customerLeaveTime;
+        }
+
+        if (orderAssigned && orderStats.orderTimer.value <= 0 || !orderAssigned)
+        {
+            orderStats.SetInactive(true);
+            orderStats.customerInfoRoot.SetActive(false);
+            orderStats.temperatureSegments.targetAttributeValue = 0;
+            orderStats.sweetnessSegments.targetAttributeValue = 0;
+            orderStats.spicinessSegments.targetAttributeValue = 0;
+            orderStats.strengthSegments.targetAttributeValue = 0;
+            orderStats.temperatureSegments.cumulativeIngredientsValue = 0;
+            orderStats.sweetnessSegments.cumulativeIngredientsValue = 0;
+            orderStats.spicinessSegments.cumulativeIngredientsValue = 0;
+            orderStats.strengthSegments.cumulativeIngredientsValue = 0;
+            orderStats.temperatureSegments.Reset();
+            orderStats.sweetnessSegments.Reset();
+            orderStats.spicinessSegments.Reset();
+            orderStats.strengthSegments.Reset();
+            orderAssigned = false;
+        }
     }
 
-    public void SetOrder(CustomerBase customer)
+    public void SetOrder(CustomerBase customerOrder)
     {
-        orderStats.customerNumberText.text = customer.customerNumber.ToString();
-        orderStats.temperatureSegments.targetAttributeValue = customer.coffeeAttributes.GetTemperature();
-        orderStats.sweetnessSegments.targetAttributeValue = customer.coffeeAttributes.GetSweetness();
-        orderStats.spicinessSegments.targetAttributeValue = customer.coffeeAttributes.GetSpiciness();
-        orderStats.strengthSegments.targetAttributeValue = customer.coffeeAttributes.GetStrength();
+        customer = customerOrder;
+        orderStats.customerInfoRoot.SetActive(true);
+        orderStats.customerNumberText.text = customerOrder.customerNumber.ToString();
+        orderStats.customerNameText.text = customerOrder.customerName;
+        orderStats.brewingStationText.text = this.name;
+        orderStats.orderTimer.value = customerOrder.orderTimer.Value;
+        orderStats.temperatureSegments.targetAttributeValue = customerOrder.coffeeAttributes.GetTemperature();
+        orderStats.sweetnessSegments.targetAttributeValue = customerOrder.coffeeAttributes.GetSweetness();
+        orderStats.spicinessSegments.targetAttributeValue = customerOrder.coffeeAttributes.GetSpiciness();
+        orderStats.strengthSegments.targetAttributeValue = customerOrder.coffeeAttributes.GetStrength();
+        orderStats.temperatureSegments.potentialIngredientValue = 0;
+        orderStats.sweetnessSegments.potentialIngredientValue = 0;
+        orderStats.spicinessSegments.potentialIngredientValue = 0;
+        orderStats.strengthSegments.potentialIngredientValue = 0;
+        orderStats.SetPotentialSweetness();
+        orderStats.SetPotentialTemperature();
+        orderStats.SetPotentialSpiciness();
+        orderStats.SetPotentialStrength();
         orderAssigned = true;
     }
 
@@ -214,9 +252,7 @@ public class BrewingStation : BaseStation, IHasProgress, IHasMinigameTiming
         if (minigameTimer >= maxMinigameTimer)
         {
             minigameTiming = false;
-            Debug.Log("Too late");
         }
-        Debug.Log("ingredientSOList.Count :" + ingredientSOList.Count);
         PrintHeldIngredientList();
     }
 
@@ -270,7 +306,6 @@ public class BrewingStation : BaseStation, IHasProgress, IHasMinigameTiming
                 return false;
             }
         }
-        Debug.Log("We got an ingredient added bro");
         return true;
     }
 

--- a/Assets/Development/Scripts/Multiplayer/Network/CharacterSelectPlayer.cs
+++ b/Assets/Development/Scripts/Multiplayer/Network/CharacterSelectPlayer.cs
@@ -37,7 +37,6 @@ public class CharacterSelectPlayer : MonoBehaviour
             readyText.SetActive(CharacterSelectReady.Instance.IsPlayerReady(playerData.clientId));
 
             playerVisual.SetPlayerColor(BaristapocalypseMultiplayer.Instance.GetPlayerColor(playerData.colorId));
-            Debug.Log("ITS WORKING");
         }
         else
         {

--- a/Assets/Development/Scripts/UI/IngredientSelectionUI.cs
+++ b/Assets/Development/Scripts/UI/IngredientSelectionUI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
-using Unity.VisualScripting;
 
 public class IngredientSelectionUI : BaseStation
 {
@@ -13,7 +12,6 @@ public class IngredientSelectionUI : BaseStation
     private bool currentStationInteraction;
 
     [SerializeField] private GameObject ingredientMenu;
-    private string hoverButtonName;
     public GameObject buttonsRoot;
     [SerializeField] private Button[] ingredientButtons;
     BrewingStation[] brewingStations;
@@ -36,7 +34,6 @@ public class IngredientSelectionUI : BaseStation
         if (!currentStationInteraction)
             return;
 
-        Debug.Log(name);
         // Detect the name of the button that the cursor is hovering over
         PointerEventData pointerEventData = new PointerEventData(EventSystem.current);
         pointerEventData.position = Input.mousePosition;
@@ -51,7 +48,6 @@ public class IngredientSelectionUI : BaseStation
             {
                 if (selectedObj == ingredientButtons[i].gameObject)
                 {
-                    Debug.Log("Button " + (i + 1) + " is selected");
                     ingredientListSOIndex = i;
                     currentIngredient = ingredientListSO[ingredientListSOIndex];
                     CalculateIngredients(currentIngredient, ingredientListSOIndex);
@@ -59,83 +55,10 @@ public class IngredientSelectionUI : BaseStation
                 }
             }
         }
-
-        //for (int i = 0; i < raycastResultList.Count; i++)
-        //{
-        //    if (raycastResultList[i].gameObject.tag == "Ingredient_UI_Button")
-        //    {
-        //        hoverButtonName = raycastResultList[i].gameObject.name;
-        //        Debug.Log("The cursor is currently over: " + hoverButtonName);
-        //    }
-        //}
-
-        //// Detects which button is being hovered over and sets the ingredient index accordingly
-        //if (hoverButtonName == "Arabica" || hoverButtonName == "CowMilk" || hoverButtonName == "Sugar" || hoverButtonName == "PlutoniumPowder" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "Arabica" || EventSystem.current.currentSelectedGameObject.name == "CowMilk" || EventSystem.current.currentSelectedGameObject.name == "Sugar" || EventSystem.current.currentSelectedGameObject.name == "PlutoniumPowder")
-        //{
-        //    ingredientListSOIndex = 0;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else if (hoverButtonName == "CosmicCacao" || hoverButtonName == "Water" || hoverButtonName == "MoonMaple" || hoverButtonName == "ButterBugs" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "CosmicCacao" || EventSystem.current.currentSelectedGameObject.name == "Water" || EventSystem.current.currentSelectedGameObject.name == "MoonMaple" || EventSystem.current.currentSelectedGameObject.name == "ButterBugs")
-        //{
-        //    ingredientListSOIndex = 1;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else if (hoverButtonName == "Excelsior" || hoverButtonName == "BlueMilk" || hoverButtonName == "GalaxyGummy" || hoverButtonName == "Brains" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "Excelsior" || EventSystem.current.currentSelectedGameObject.name == "BlueMilk" || EventSystem.current.currentSelectedGameObject.name == "GalaxyGummy" || EventSystem.current.currentSelectedGameObject.name == "Brains")
-        //{
-        //    ingredientListSOIndex = 2;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else if (hoverButtonName == "Robusta" || hoverButtonName == "Moonshine" || hoverButtonName == "MochaMiel" || hoverButtonName == "FunkyFungus" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "Robusta" || EventSystem.current.currentSelectedGameObject.name == "Moonshine" || EventSystem.current.currentSelectedGameObject.name == "MochaMiel" || EventSystem.current.currentSelectedGameObject.name == "FunkyFungus")
-        //{
-        //    ingredientListSOIndex = 3;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else if (hoverButtonName == "KopiLuwak" || hoverButtonName == "LavaGuava" || hoverButtonName == "Molasses" || hoverButtonName == "JupiterJelly" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "KopiLuwak" || EventSystem.current.currentSelectedGameObject.name == "LavaGuava" || EventSystem.current.currentSelectedGameObject.name == "Molasses" || EventSystem.current.currentSelectedGameObject.name == "JupiterJelly")
-        //{
-        //    ingredientListSOIndex = 4;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else if (hoverButtonName == "SlurpJuice" || hoverButtonName == "Gobstopper" || hoverButtonName == "MeatCube" || hoverButtonName == "Undefined" ||
-        //    EventSystem.current.currentSelectedGameObject.name == "SlurpJuice" || EventSystem.current.currentSelectedGameObject.name == "Gobstopper" || EventSystem.current.currentSelectedGameObject.name == "MeatCube" || EventSystem.current.currentSelectedGameObject.name == "Undefined")
-        //{
-        //    ingredientListSOIndex = 5;
-        //    currentIngredient = ingredientListSO[ingredientListSOIndex];
-        //    Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
-        //    CalculateIngredients(currentIngredient, ingredientListSOIndex);
-        //}
-        //else
-        //{
-        //    if (orderStatsRoot != null && orderStatsRoot.childCount > 0 || EventSystem.current.currentSelectedGameObject == null)
-        //    {
-        //        OrderStats orderStats = orderStatsRoot.GetChild(0).GetComponent<OrderStats>();
-        //        orderStats.temperatureSegments.potentialIngredientValue = 0;
-        //        orderStats.sweetnessSegments.potentialIngredientValue = 0;
-        //        orderStats.spicinessSegments.potentialIngredientValue = 0;
-        //        orderStats.strengthSegments.potentialIngredientValue = 0;
-        //    }
-        //}
     }
 
     public void AddIngredient()
     {
-        // This was the code that spawned the ingredient into the player hands
-        //Ingredient.SpawnIngredient(currentIngredient, player);
-        //player.GetNumberOfIngredients();
         EventSystem.current.SetSelectedGameObject(null);
         SoundManager.Instance.PlayOneShot(SoundManager.Instance.audioClipRefsSO.interactStation);
         player.movementToggle = true;
@@ -157,9 +80,7 @@ public class IngredientSelectionUI : BaseStation
         if (other.tag == "Player")
         {
             player = other.GetComponent<PlayerController>();
-            Debug.Log("Player Collided With trigger");
-
-            player.movementToggle = false;
+            //player.movementToggle = false;
 
             //Display UI ingredient menu
             Show(ingredientMenu);
@@ -170,8 +91,6 @@ public class IngredientSelectionUI : BaseStation
     {
         if (other.tag == "Player")
         {
-            Debug.Log("Player left trigger collider");
-
             player.movementToggle = true;
 
             // Hide UI ingredient menu
@@ -206,7 +125,6 @@ public class IngredientSelectionUI : BaseStation
             orderStats.sweetnessSegments.potentialIngredientValue = currentIngredient.sweetness + orderStats.sweetnessSegments.cumulativeIngredientsValue;
             orderStats.spicinessSegments.potentialIngredientValue = currentIngredient.spiciness + orderStats.spicinessSegments.cumulativeIngredientsValue;
             orderStats.strengthSegments.potentialIngredientValue = currentIngredient.strength + orderStats.strengthSegments.cumulativeIngredientsValue;
-            Debug.Log("The current IngredientListSOIndex is: " + ingredientListSOIndex);
             orderStats.SetPotentialSweetness();
             orderStats.SetPotentialTemperature();
             orderStats.SetPotentialSpiciness();

--- a/Assets/Development/Scripts/UI/OrderStats.cs
+++ b/Assets/Development/Scripts/UI/OrderStats.cs
@@ -1,17 +1,19 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
 public class OrderStats : MonoBehaviour
 {
     [Header("Customer Order")]
+    [SerializeField] public GameObject customerInfoRoot;
     [SerializeField] public Text customerNumberText;
+    [SerializeField] public Text customerNameText;
+    [SerializeField] public Text brewingStationText;
+    [SerializeField] public Slider orderTimer;
     [SerializeField] public OrderStatsSegments temperatureSegments;
     [SerializeField] public OrderStatsSegments sweetnessSegments;
     [SerializeField] public OrderStatsSegments spicinessSegments;
     [SerializeField] public OrderStatsSegments strengthSegments;
-    
+
     [Header("Customer Review")]
     [SerializeField] private GameObject customerReview;
     [SerializeField] private CustomerBase orderOwner;
@@ -29,6 +31,23 @@ public class OrderStats : MonoBehaviour
         sweetnessSegments.targetAttributeValue = customer.coffeeAttributes.GetSweetness();
         spicinessSegments.targetAttributeValue = customer.coffeeAttributes.GetSpiciness();
         strengthSegments.targetAttributeValue = customer.coffeeAttributes.GetStrength();
+    }
+
+    // Fade of unfade the order stats
+    public void SetInactive(bool isInactive)
+    {
+        Image[] images = GetComponentsInChildren<Image>(true); // The 'true' parameter includes inactive GameObjects
+        foreach (Image image in images)
+        {
+            Color imageColor = image.GetComponent<Image>().color;
+            if (isInactive)
+            {
+                imageColor.a = 0.2f;
+            }
+            else
+                imageColor.a = 1.0f;
+            image.color = imageColor;
+        }
     }
 
     public void SetTemperature()

--- a/Assets/Development/Scripts/UI/OrderStatsSegments.cs
+++ b/Assets/Development/Scripts/UI/OrderStatsSegments.cs
@@ -70,12 +70,15 @@ public class OrderStatsSegments : MonoBehaviour
 
     private void SetPotential(GameObject potentialSegment)
     {
-        if (cumulativeIngredientsValue + potentialIngredientValue == targetAttributeValue)
+        int cumulativeValue = MapValue(cumulativeIngredientsValue);
+        int potentialValue = MapValue(potentialIngredientValue);
+        int targetValue = MapValue(targetAttributeValue);
+        if (cumulativeValue + potentialValue == targetValue)
         {
             potentialSegment.GetComponent<Image>().color = Color.green;
         }
 
-        else if (cumulativeIngredientsValue + potentialIngredientValue != targetAttributeValue)
+        else if (cumulativeValue + potentialValue != targetValue)
         {
             Reset();
             potentialSegment.GetComponent<Image>().color = Color.white;

--- a/Assets/Development/Scripts/UI/OrderStatsSegments.cs
+++ b/Assets/Development/Scripts/UI/OrderStatsSegments.cs
@@ -27,31 +27,14 @@ public class OrderStatsSegments : MonoBehaviour
             segment.GetComponent<Image>().color = segmentColor;
             segment.SetActive(false);
         }
-        //targetAttributeValue = 0;
-        //cumulativeIngredientsValue = 0;
     }
 
     private void Update()
     {
-        // Make thhis not be required every frame
-        if (targetAttributeValue < 0)
-        {
-            GameObject targetSegment = segments[(segments.Length / 2) + targetAttributeValue];
-            SetTarget(targetSegment);
-        }
-
-        if (targetAttributeValue > 0)
-        {
-            GameObject targetSegment = segments[(segments.Length / 2 - 1) + targetAttributeValue];
-            SetTarget(targetSegment);
-        }
-
-        if (targetAttributeValue == 0)
-        {
-            targetAttributeSelector.transform.SetParent(gameObject.transform);
-            targetAttributeSelector.transform.position = gameObject.transform.position;
-            targetAttributeSelector.SetActive(false);
-        }
+        // Make this not be required every frame
+        int targetValue = MapValue(targetAttributeValue);
+        GameObject targetSegment = segments[targetValue];
+        SetTarget(targetSegment);
     }
 
     public void UpdateSegmentColors(int cumulative)
@@ -65,29 +48,15 @@ public class OrderStatsSegments : MonoBehaviour
             segment.SetActive(false);
         }
 
-        if (cumulative >= segments.Length / 2)
-        {
-            Debug.LogError("Value is greater than the number of segments.");
-            return;
-        }
+        int potentialValue = MapValue(potentialIngredientValue);
+        SetPotential(segments[potentialValue]);
+    }
 
-        if (potentialIngredientValue < 0)
-        {
-            int startIndex = segments.Length / 2;
-            int endIndex = startIndex + cumulative;
-            SetPotential(segments[endIndex]);
-        }
-
-        if (potentialIngredientValue > 0)
-        {
-            int startIndex = segments.Length / 2 - 1;
-            int endIndex = startIndex + cumulative;
-            SetPotential(segments[endIndex]);
-        }
-
-        // add logic for zero value. need to update ui object to accept 0
-        if (potentialIngredientValue == 0)
-            potentialAttributeSelector.SetActive(false);
+    // Mapping -7 to +7 to 0 to 14
+    public int MapValue(int originalValue)
+    {
+        // Assuming originalValue is in the range of -7 to +7
+        return originalValue + 7;
     }
 
     private void SetTarget(GameObject targetSegment)
@@ -101,7 +70,6 @@ public class OrderStatsSegments : MonoBehaviour
 
     private void SetPotential(GameObject potentialSegment)
     {
-
         if (cumulativeIngredientsValue + potentialIngredientValue == targetAttributeValue)
         {
             potentialSegment.GetComponent<Image>().color = Color.green;
@@ -110,7 +78,7 @@ public class OrderStatsSegments : MonoBehaviour
         else if (cumulativeIngredientsValue + potentialIngredientValue != targetAttributeValue)
         {
             Reset();
-            potentialSegment.GetComponent<Image>().color = Color.blue;
+            potentialSegment.GetComponent<Image>().color = Color.clear;
         }
         potentialSegment.SetActive(true);
         potentialAttributeSelector.transform.SetParent(potentialSegment.transform);

--- a/Assets/Development/Scripts/UI/OrderStatsSegments.cs
+++ b/Assets/Development/Scripts/UI/OrderStatsSegments.cs
@@ -78,6 +78,7 @@ public class OrderStatsSegments : MonoBehaviour
         else if (cumulativeIngredientsValue + potentialIngredientValue != targetAttributeValue)
         {
             Reset();
+            potentialSegment.GetComponent<Image>().color = Color.white;
             potentialSegment.GetComponent<Image>().color = Color.clear;
         }
         potentialSegment.SetActive(true);

--- a/Assets/Development/Scripts/UI/OrderStatsSegments.cs
+++ b/Assets/Development/Scripts/UI/OrderStatsSegments.cs
@@ -1,5 +1,7 @@
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
+using static UnityEngine.Rendering.HableCurve;
 
 public class OrderStatsSegments : MonoBehaviour
 {
@@ -9,24 +11,29 @@ public class OrderStatsSegments : MonoBehaviour
     public int targetAttributeValue;
     public GameObject targetAttributeSelector;
     public GameObject potentialAttributeSelector;
-    private int previousCumulativeIngredientsValue;
 
     private void Start()
     {
-        // Ensure all segments to inactive
+        Reset();
+    }
+
+    public void Reset()
+    {
         foreach (var segment in segments)
         {
             segment.GetComponent<Image>().color = Color.green;
             Color segmentColor = segment.GetComponent<Image>().color;
             segmentColor.a = 1.0f;
+            segment.GetComponent<Image>().color = segmentColor;
             segment.SetActive(false);
         }
-        cumulativeIngredientsValue = 0;
+        //targetAttributeValue = 0;
+        //cumulativeIngredientsValue = 0;
     }
 
     private void Update()
     {
-        //UpdateSegmentColors(cumulativeIngredientsValue); // remove this later so it doesn't run every frame
+        // Make thhis not be required every frame
         if (targetAttributeValue < 0)
         {
             GameObject targetSegment = segments[(segments.Length / 2) + targetAttributeValue];
@@ -37,6 +44,13 @@ public class OrderStatsSegments : MonoBehaviour
         {
             GameObject targetSegment = segments[(segments.Length / 2 - 1) + targetAttributeValue];
             SetTarget(targetSegment);
+        }
+
+        if (targetAttributeValue == 0)
+        {
+            targetAttributeSelector.transform.SetParent(gameObject.transform);
+            targetAttributeSelector.transform.position = gameObject.transform.position;
+            targetAttributeSelector.SetActive(false);
         }
     }
 
@@ -61,7 +75,6 @@ public class OrderStatsSegments : MonoBehaviour
         {
             int startIndex = segments.Length / 2;
             int endIndex = startIndex + cumulative;
-            //SetPotential(segments[endIndex + potentialIngredientValue]);
             SetPotential(segments[endIndex]);
         }
 
@@ -69,14 +82,12 @@ public class OrderStatsSegments : MonoBehaviour
         {
             int startIndex = segments.Length / 2 - 1;
             int endIndex = startIndex + cumulative;
-            //SetPotential(segments[endIndex + potentialIngredientValue]);
             SetPotential(segments[endIndex]);
         }
 
         // add logic for zero value. need to update ui object to accept 0
         if (potentialIngredientValue == 0)
             potentialAttributeSelector.SetActive(false);
-            //return; 
     }
 
     private void SetTarget(GameObject targetSegment)
@@ -90,10 +101,17 @@ public class OrderStatsSegments : MonoBehaviour
 
     private void SetPotential(GameObject potentialSegment)
     {
+
         if (cumulativeIngredientsValue + potentialIngredientValue == targetAttributeValue)
+        {
             potentialSegment.GetComponent<Image>().color = Color.green;
+        }
+
         else if (cumulativeIngredientsValue + potentialIngredientValue != targetAttributeValue)
-            potentialSegment.GetComponent<Image>().color = Color.clear;
+        {
+            Reset();
+            potentialSegment.GetComponent<Image>().color = Color.blue;
+        }
         potentialSegment.SetActive(true);
         potentialAttributeSelector.transform.SetParent(potentialSegment.transform);
         potentialAttributeSelector.transform.position = potentialSegment.transform.position;

--- a/Assets/Scenes/MasterScenes/T5M3_BUILD.unity
+++ b/Assets/Scenes/MasterScenes/T5M3_BUILD.unity
@@ -1573,6 +1573,7 @@ Transform:
   - {fileID: 634637106}
   - {fileID: 1050217343}
   - {fileID: 874483910}
+  - {fileID: 828276133}
   m_Father: {fileID: 0}
   m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3197,6 +3198,10 @@ PrefabInstance:
     - target: {fileID: 5491920222206312024, guid: 4f04091c3505b7c40aae316fa5f75b22, type: 3}
       propertyPath: m_Name
       value: CoffeeGrinderStation
+      objectReference: {fileID: 0}
+    - target: {fileID: 5491920222206312024, guid: 4f04091c3505b7c40aae316fa5f75b22, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5688027606721445169, guid: 4f04091c3505b7c40aae316fa5f75b22, type: 3}
       propertyPath: m_Enabled
@@ -9362,6 +9367,76 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7328240650680940546, guid: bbc6ae028c642f84b90d03e82a1440fd, type: 3}
   m_PrefabInstance: {fileID: 1390994318}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &828276132
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 346700246}
+    m_Modifications:
+    - target: {fileID: 968189847249797911, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 3653101751
+      objectReference: {fileID: 0}
+    - target: {fileID: 2302913697864026037, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_Name
+      value: BrewingStation 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4448117747942318682, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: orderStatsRoot
+      value: 
+      objectReference: {fileID: 824060477}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.281
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+--- !u!4 &828276133 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
+  m_PrefabInstance: {fileID: 828276132}
+  m_PrefabAsset: {fileID: 0}
 --- !u!43 &838687747
 Mesh:
   m_ObjectHideFlags: 0
@@ -14165,23 +14240,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2302913697864026037, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: m_Name
-      value: BrewingStation
+      value: BrewingStation 1
       objectReference: {fileID: 0}
     - target: {fileID: 4448117747942318682, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: orderStatsRoot
       value: 
       objectReference: {fileID: 824060477}
-    - target: {fileID: 4448117747942318682, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
-      propertyPath: orderStatsPrefab
-      value: 
-      objectReference: {fileID: 5308759679528095304, guid: 5de1edabd0f69164db14f8d4539228bf, type: 3}
     - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -21.88
+      value: -23.26
       objectReference: {fileID: 0}
     - target: {fileID: 8086891939505322414, guid: 35190cf297479a541b3384c9d8a87c04, type: 3}
       propertyPath: m_LocalPosition.y


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/CGxMcjmK/353-order-timer-ui
https://trello.com/c/TvsFIoF9/374-decide-if-were-grinding-beans
https://trello.com/c/PpF5yson/401-add-ability-to-use-multiple-brewing-stations
https://trello.com/c/lobKil2e/403-add-ui-support-for-ingredients-that-equal-zero-value

# Description of changes
- Added multiple brewing stations.  Can add as many as you want and the game will let you use them without any additional code
- Added customer countdown timer to brewing station UI
- Added customer name, customer number, brewing station number to UI
- Reset all brewing station on order delivered
- Reset brewing station if order not delivered but timer ran out
- Disabled "interactable" on the sink slider because of the eventsystem picking it up
- Brewing station UI is faded when not active, becomes active when order is being processed
- Removed some seemingly unnecessary debug.log lines in various files
- Changed segment values to a map on the scale
- Added zero values
- Green segment miscalculation bug fixed.  Values were not mapped before comparison

# Related notes
- 2nd machine is not fully functional yet, but it's getting pretty consistent with hitting perfect drinks
- The black colour for selected potential value will be changed to transparent later

