### PR TITLE
Trash consequence, bug fixes

### DIFF
--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -168,8 +168,6 @@ public class CustomerBase : Base
         if (agent.remainingDistance < distThreshold)
         {
             Destroy(gameObject);
-            Debug.Log("this is our disappearing customer issue"); // if you see this, the customer probably disappeared and the review didn't show.  something about being close to the entrance causes the player to destroy on leaving
-            //UIManager.Instance.RemoveCustomerUiOrder(this);
         }
     }
 

--- a/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
@@ -197,66 +197,6 @@ public class UIManager : Singleton<UIManager>
         audioSettings.SetActive(false);
     }
 
-    //public void ShowCustomerUiOrder(CustomerBase customer)
-    //{
-    //    orderStats = Instantiate(ordersUiPrefab, ordersPanel).GetComponent<OrderStats>();
-    //    orderStats.Initialize(customer);
-    //}
-
-    /*public void ShowCustomerReview(CustomerBase customer)
-    {
-        // This can be better by moving customer review script to the customer object
-        foreach (Transform t in ordersPanel)
-        {
-            OrderStats o = t.GetComponent<OrderStats>();
-            if (o != null)
-            {
-                if (o.GetOrderOwner() == customer)
-                {
-                    Transform customerReviewTransform = t.gameObject.transform.Find("CustomerReview");
-                    Text customerReviewText = customerReviewTransform.gameObject.GetComponent<Text>();
-                    customerReview = customerReviewTransform.GetComponentInParent<CustomerReview>();
-                    customerReview.GenerateReview(customer);
-                    customerReviewText.text = customerReview.ReviewText;
-                    UpdateStarRating(customerReview.ReviewScore);
-                    customerReviewTransform.gameObject.SetActive(true);
-                    return;
-                }
-                else
-                {
-                    Debug.Log($"Customer Order UI not found for {customer.customerNumber}");
-                }
-            }
-        }
-    }*/
-
-    public void RemoveCustomerUiOrder(CustomerBase customer)
-    {
-        foreach (Transform t in ordersPanel)
-        {
-            OrderStats o = t.GetComponent<OrderStats>();
-            if (o != null)
-            {
-                if (o.GetOrderOwner() == customer)
-                {
-                    Destroy(t.gameObject);
-                    return;
-                }
-                else if (o.GetOrderOwner().customerNumber == customer.customerNumber)
-                {
-                    // This exists because pickups are cloned, so the connection to the order prefab is lost
-                    // Just search for the customer based on their number in case owner is lost
-                    Destroy(t.gameObject);
-                    return;
-                }
-                else
-                {
-                    Debug.Log($"Customer Order UI not found for {customer.customerNumber}");
-                }
-            }
-        }
-    }
-
     public void UpdateStarRating(int reviewScore)
     {
         Transform starRating = customerReview.transform.Find("CustomerReview/StarRating");

--- a/Assets/Development/Scripts/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/PlayerController.cs
@@ -755,6 +755,11 @@ public class PlayerController : NetworkBehaviour, IIngredientParent, IPickupObje
 
     public void OnBrewingStationEmpty()
     {
+        if (OrderManager.Instance.brewingStations[currentBrewingStation].ingredientSOList.Count > 0)
+        {
+            AISupervisor.Instance.SupervisorMessageToDisplay("I'm taking that out of your tips!");
+            GameManager.Instance.moneySystem.AdjustMoneyByAmount(10, false);
+        }
         OrderManager.Instance.brewingStations[currentBrewingStation].Empty();
         OrderManager.Instance.orderStats[currentBrewingStation].ResetAll();
     }


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/iwSpoHDN/411-trash-button-consequence
https://trello.com/c/Wn7OH6tu/463-brewing-stats-disappears-unexpectedly-likely-when-customers-are-thrown

# Description of changes
- Deduct $10 when trashing ingredients, have supervisor alert
- Remove references to ShowCustomerUiOrder, RemoveCustomerUiOrder as they are not needed and cause errors
- Removed a really old debug.log that no longer makes sense

