### PR TITLE
Fixes

### DIFF
--- a/Assets/Development/Prefabs/Enviorment/Level/BP_TableCircle.prefab
+++ b/Assets/Development/Prefabs/Enviorment/Level/BP_TableCircle.prefab
@@ -58,7 +58,7 @@ NavMeshObstacle:
   m_Enabled: 1
   serializedVersion: 3
   m_Shape: 0
-  m_Extents: {x: 3, y: 0.5, z: 3}
+  m_Extents: {x: 2, y: 0.5, z: 2}
   m_MoveThreshold: 0.1
   m_Carve: 1
   m_CarveOnlyStationary: 1

--- a/Assets/Development/Prefabs/Stations/Environment/Mop.prefab
+++ b/Assets/Development/Prefabs/Stations/Environment/Mop.prefab
@@ -73,6 +73,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3366720151648082664}
+  - component: {fileID: 6066792214599436349}
   - component: {fileID: 1125012182506645654}
   - component: {fileID: 3907308811520950312}
   - component: {fileID: 7237732476668811835}
@@ -103,6 +104,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6066792214599436349
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3366720151648082663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 708f7ad3a86e8d543945adc57a694df8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1125012182506645654
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -102,7 +102,7 @@ public class CustomerBase : Base
 
         agent = GetComponent<NavMeshAgent>();
         exit = CustomerManager.Instance.GetExit();
-        if (distThreshold <= 0) distThreshold = 0.5f;
+        if (distThreshold <= 0) distThreshold = 0.1f;
         
 
         customerReviewPanel = GameObject.FindGameObjectWithTag("CustomerReviewPanel");

--- a/Assets/Development/Scripts/Environment/Physics/BlackHole.cs
+++ b/Assets/Development/Scripts/Environment/Physics/BlackHole.cs
@@ -17,7 +17,7 @@ public class BlackHole : MonoBehaviour
 
     void OnTriggerStay(Collider other)
     {
-        if (other.attachedRigidbody)
+        if (other.attachedRigidbody && other.gameObject.GetComponent<PlayerController>() == null)
         {
             ApplyBlackHoleEffect(other.attachedRigidbody);
         }

--- a/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs
+++ b/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MopBehavior : MonoBehaviour
+{
+    [SerializeField] private Vector3 startPos;
+    [SerializeField] private Quaternion startRot;  
+    [SerializeField] private bool isNotAtStartingTrans = false;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        startPos = transform.position;
+        startRot = transform.rotation;
+    }
+
+    public void ReturnMop()
+    {
+        StartCoroutine(DelayReturnMop());
+    }
+
+    public IEnumerator DelayReturnMop()
+    {
+        yield return new WaitForSeconds(2f);
+
+        transform.position = startPos;
+        transform.rotation = startRot;
+    }
+
+}

--- a/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs.meta
+++ b/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 708f7ad3a86e8d543945adc57a694df8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Development/Scripts/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/PlayerController.cs
@@ -946,13 +946,17 @@ public class PlayerController : NetworkBehaviour, IIngredientParent, IPickupObje
         yield return new WaitForSeconds(1.0f); // hard coded while new player statemachine is dead
 
         if (pickup != null) 
-        { 
+        {
+            
             pickup.GetComponent<IngredientFollowTransform>().SetTargetTransform(pickup.transform);
             pickup.EnablePickupColliders(pickup);
             pickup.GetCollider().enabled = true;
 
             pickup.transform.GetComponent<Rigidbody>().AddForce(transform.forward * (pickupThrowForce * pickup.GetThrowForceMultiplier()));
+            if (pickup.gameObject.GetComponent<MopBehavior>() != null) pickup.gameObject.GetComponent<MopBehavior>().ReturnMop();
             pickup.ClearPickupOnParent();
+
+           
         }
         movementToggle = true;
     }


### PR DESCRIPTION
BlackHole should not affect objects with component playercontroller Adjusted Navmesh for dissappearing customers(Hopefully fixes it)

Mop now teleports back when thrown by player

# Related board task URL
https://

# Description of changes
- Changed the Collider to detect if the colliding gameobject does not have component player contoller
- Adjusted Navmesh to hopefully get rid of dissapearing customers when leaving(needs more testing)
- Added a returnMop to mop when thrown

# Related notes
- 

