### PR TITLE
Fixes to Spills UI && mop physics

### DIFF
--- a/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs
+++ b/Assets/Development/Scripts/Player/Pickup/MopBehavior.cs
@@ -24,6 +24,7 @@ public class MopBehavior : MonoBehaviour
     {
         yield return new WaitForSeconds(2f);
 
+        GetComponent<Rigidbody>().velocity = Vector3.zero;
         transform.position = startPos;
         transform.rotation = startRot;
     }

--- a/Assets/Development/Scripts/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/PlayerController.cs
@@ -277,7 +277,7 @@ public class PlayerController : NetworkBehaviour, IIngredientParent, IPickupObje
                     if (Pickup.attributes.Contains(Pickup.PickupAttribute.CleansUpSpills)) 
                     {
                         //_hasMop = true;
-                        SetSelectedSpill(spill);
+                        if(selectedSpill == null) SetSelectedSpill(spill);
                         selectedSpill.ShowUi();
                         if(Keyboard.current.qKey.wasPressedThisFrame)
                         {


### PR DESCRIPTION
Added Check for spills to make sure only 1 is selected at a time Mop now is at zero velocity when returning to pos

# Related board task URL
https://trello.com/c/KJXjvo35
https://trello.com/c/8ugSZTq0

# Description of changes
- 

# Related notes
- 

