### PR TITLE
Default medium, no more difficulty buttons

### DIFF
--- a/Assets/Development/Scripts/Helpers/GameValueHolder.cs
+++ b/Assets/Development/Scripts/Helpers/GameValueHolder.cs
@@ -15,7 +15,7 @@ public class GameValueHolder : Singleton<GameValueHolder>
     private void Start()
     {
         difficultySettings = new DifficultySettings();
-        SetCurrentDifficultyTo("Easy");
+        SetCurrentDifficultyTo("Medium");
     }
 
     public void SetCurrentDifficultyTo(string difficulty)

--- a/Assets/Scenes/MasterScenes/MainMenuScene.unity
+++ b/Assets/Scenes/MasterScenes/MainMenuScene.unity
@@ -1125,7 +1125,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &211896494
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4135,7 +4135,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1020053361
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5011,7 +5011,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1162969782}
-  m_LocalRotation: {x: 0.0012096625, y: -0.0027395121, z: 0.0000033139, w: 0.9999955}
+  m_LocalRotation: {x: 0.0012096625, y: -0.002739512, z: 0.0000033138995, w: 0.9999955}
   m_LocalPosition: {x: 6.566024, y: -1.3139915, z: -25.345116}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -11615,7 +11615,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1526104752}
-  m_LocalRotation: {x: 0.0012096625, y: -0.0027395121, z: 0.0000033139, w: 0.9999955}
+  m_LocalRotation: {x: 0.0012096625, y: -0.002739512, z: 0.0000033138995, w: 0.9999955}
   m_LocalPosition: {x: 13.869999, y: 35.86128, z: 60.878387}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -12212,7 +12212,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1597643212
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/No8oAxmE/823-default-medium-disable-difficulty-buttons

# Description of changes
- Disabled difficulty buttons
- Set default to medium

# Related notes
- OrderStats has a bug at some point last week that resets target segments to zero when picking up brewed drink.  Shouldn't be reset until delivered

