### PR TITLE
Roomba namespace errors block build

### DIFF
--- a/Assets/Development/Scripts/AI/RoombotConsole.cs
+++ b/Assets/Development/Scripts/AI/RoombotConsole.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEditor.SearchService;
 using UnityEngine;
 
 public class RoombotConsole : Base


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/iJjywUbJ/843-cannot-build-due-to-roomba-namespace

# Description of changes
- Removed UnityEditor.SearchService namespace from Roomba
- Was unused anyway

