### PR TITLE
Game over adjustments

### DIFF
--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -818,6 +818,7 @@ public class CustomerBase : Base
     public void GameOverLeave() 
     {
         customerAnimator.CrossFadeInFixedTime(Customer_WalkHash, CrossFadeDuration); // Customer1 walk animation
+        if (agent.isStopped) agent.isStopped = false;
         agent.SetDestination(exit);
         SetCustomerState(CustomerState.Leaving);
     }

--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -817,9 +817,8 @@ public class CustomerBase : Base
 
     public void GameOverLeave() 
     {
-        customerAnimator.CrossFadeInFixedTime(Customer_WalkHash, CrossFadeDuration); // Customer1 walk animation
         if (agent.isStopped) agent.isStopped = false;
-        agent.SetDestination(exit);
+        Walkto(exit);
         SetCustomerState(CustomerState.Leaving);
     }
 

--- a/Assets/Development/Scripts/AI/CustomerBase.cs
+++ b/Assets/Development/Scripts/AI/CustomerBase.cs
@@ -815,6 +815,14 @@ public class CustomerBase : Base
         player.movementToggle = true;
     }
 
+    public void GameOverLeave() 
+    {
+        customerAnimator.CrossFadeInFixedTime(Customer_WalkHash, CrossFadeDuration); // Customer1 walk animation
+        agent.SetDestination(exit);
+        SetCustomerState(CustomerState.Leaving);
+    }
+
+
     public override void OnDestroy()
     {
         Debug.Log("destroying customer");

--- a/Assets/Development/Scripts/AI/CustomerManager.cs
+++ b/Assets/Development/Scripts/AI/CustomerManager.cs
@@ -177,6 +177,8 @@ public class CustomerManager : Singleton<CustomerManager>
     {
         yield return new WaitForSeconds(delayS);
 
+        if (GameManager.Instance.IsGamePlaying() == false) yield break;
+
         //while(gameObject is playin) set timer
         if (customerPrefab != null)
         {

--- a/Assets/Development/Scripts/AI/CustomerManager.cs
+++ b/Assets/Development/Scripts/AI/CustomerManager.cs
@@ -383,6 +383,18 @@ public class CustomerManager : Singleton<CustomerManager>
         return result;
     }
 
+    public void BarClosing()
+    {
+        CustomerBase[] _customersInStore = FindObjectsOfType<CustomerBase>();
+
+        for (int i = 0; i < _customersInStore.Length; i++)
+        {
+            CustomerBase _customerInStore = _customersInStore[i];
+            _customerInStore.GameOverLeave();
+        }
+    }
+
+
     public int GetCustomerLefttoServe()
     {
         return customersLefttoServe;

--- a/Assets/Development/Scripts/Helpers/Managers/DifficultySettings.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/DifficultySettings.cs
@@ -95,7 +95,7 @@ public class DifficultySettings
         if (Shift >= MaxShift)
         {
             //Trigger End Game
-            GameManager.Instance.iSEndGame = true;
+            GameManager.Instance.GameOver();
             UIManager.Instance.shiftEvaluationUI.SetActive(false);
 
             return;

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -155,13 +155,19 @@ public class GameManager : NetworkBehaviour
 
         if (allClientsReady) 
         {
-            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
-            for (int i = 0; i < playerControllers.Length; i++)
-            {
-                playerControllers[i].movementToggle = true;
-                Debug.Log($"Player {i} has been movement enabled");
-            }
+            ActivateClientsMovementClientRpc();
             gameState.Value = GameState.CountdownToStart;
+        }
+    }
+
+    [ClientRpc]
+    private void ActivateClientsMovementClientRpc()
+    {
+        PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
+        for (int i = 0; i < playerControllers.Length; i++)
+        {
+            playerControllers[i].movementToggle = true;
+            Debug.Log($"Player {i} has been movement enabled");
         }
     }
 

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -159,6 +159,7 @@ public class GameManager : NetworkBehaviour
             for (int i = 0; i < playerControllers.Length; i++)
             {
                 playerControllers[i].movementToggle = true;
+                Debug.Log($"Player {i} has been movement enabled");
             }
             gameState.Value = GameState.CountdownToStart;
         }

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -297,11 +297,23 @@ public class GameManager : NetworkBehaviour
     {
         if (isGamePaused.Value) 
         {
+            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
+            for (int i = 0; i < playerControllers.Length; i++)
+            {
+                playerControllers[i].movementToggle = false;
+            }
+
             Time.timeScale = 0f;
             OnMultiplayerGamePaused?.Invoke(this, EventArgs.Empty);
         }
         else
         {
+            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
+            for (int i = 0; i < playerControllers.Length; i++)
+            {
+                playerControllers[i].movementToggle = true;
+            }
+
             Time.timeScale = 1f;
             OnMultiplayerGameUnpaused?.Invoke(this, EventArgs.Empty);
         }

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -224,9 +224,10 @@ public class GameManager : NetworkBehaviour
                 break;
 
             case GameState.GameOver:
-                Debug.LogWarning("Game Over......");
-                PlayerController playerController = FindObjectOfType<PlayerController>();
-                playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
+               // Debug.LogWarning("Game Over......");
+               // PlayerController playerController = FindObjectOfType<PlayerController>();
+               // playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
+               // playerController.movementToggle = false;
                 break; 
         }
 
@@ -260,6 +261,11 @@ public class GameManager : NetworkBehaviour
 
     public bool IsGameOver()
     {
+        Debug.LogWarning("Game Over......");
+        PlayerController playerController = FindObjectOfType<PlayerController>();
+        playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
+        playerController.movementToggle = false;
+
         return gameState.Value == GameState.GameOver;
     }
 

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -201,7 +201,6 @@ public class GameManager : NetworkBehaviour
 
                 timeSinceStart += Time.deltaTime;
 
-                if (Input.GetKeyDown(KeyCode.G)) iSEndGame = true;
 
                 if (currentDifficulty != null)
                 {
@@ -227,11 +226,7 @@ public class GameManager : NetworkBehaviour
                 break;
 
             case GameState.GameOver:
-                Debug.LogWarning("Game Over......");
-                PlayerController playerController = FindObjectOfType<PlayerController>();
-                playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
-                playerController.movementToggle = false;
-                CustomerManager.Instance.BarClosing();
+                
                 break; 
         }
 
@@ -319,6 +314,16 @@ public class GameManager : NetworkBehaviour
             Transform playerTransform = Instantiate(player1Prefab, playerSpawnPoints[(int)clientId]);
             playerTransform.GetComponent<NetworkObject>().SpawnAsPlayerObject(clientId, true);
         }
+    }
+
+    public void GameOver()
+    {
+        Debug.LogWarning("Game Over......");
+        PlayerController playerController = FindObjectOfType<PlayerController>();
+        //playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
+        playerController.movementToggle = false;
+        CustomerManager.Instance.BarClosing();
+        iSEndGame = true;
     }
 
     public void TogglePauseGame()

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -155,6 +155,11 @@ public class GameManager : NetworkBehaviour
 
         if (allClientsReady) 
         {
+            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
+            for (int i = 0; i < playerControllers.Length; i++)
+            {
+                playerControllers[i].movementToggle = true;
+            }
             gameState.Value = GameState.CountdownToStart;
         }
     }
@@ -297,23 +302,11 @@ public class GameManager : NetworkBehaviour
     {
         if (isGamePaused.Value) 
         {
-            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
-            for (int i = 0; i < playerControllers.Length; i++)
-            {
-                playerControllers[i].movementToggle = false;
-            }
-
             Time.timeScale = 0f;
             OnMultiplayerGamePaused?.Invoke(this, EventArgs.Empty);
         }
         else
         {
-            PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
-            for (int i = 0; i < playerControllers.Length; i++)
-            {
-                playerControllers[i].movementToggle = true;
-            }
-
             Time.timeScale = 1f;
             OnMultiplayerGameUnpaused?.Invoke(this, EventArgs.Empty);
         }

--- a/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/GameManager.cs
@@ -6,6 +6,7 @@ using Unity.Netcode;
 using System.Collections;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.UI;
+using UnityEngine.InputSystem;
 
 [DefaultExecutionOrder(-1)]
 public class GameManager : NetworkBehaviour
@@ -200,6 +201,8 @@ public class GameManager : NetworkBehaviour
 
                 timeSinceStart += Time.deltaTime;
 
+                if (Input.GetKeyDown(KeyCode.G)) iSEndGame = true;
+
                 if (currentDifficulty != null)
                 {
                     // Adjust the difficulty based on time passed
@@ -224,10 +227,11 @@ public class GameManager : NetworkBehaviour
                 break;
 
             case GameState.GameOver:
-               // Debug.LogWarning("Game Over......");
-               // PlayerController playerController = FindObjectOfType<PlayerController>();
-               // playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
-               // playerController.movementToggle = false;
+                Debug.LogWarning("Game Over......");
+                PlayerController playerController = FindObjectOfType<PlayerController>();
+                playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
+                playerController.movementToggle = false;
+                CustomerManager.Instance.BarClosing();
                 break; 
         }
 
@@ -261,11 +265,6 @@ public class GameManager : NetworkBehaviour
 
     public bool IsGameOver()
     {
-        Debug.LogWarning("Game Over......");
-        PlayerController playerController = FindObjectOfType<PlayerController>();
-        playerController.anim.CrossFadeInFixedTime(BP_Barista_SufferHash, CrossFadeDuration);
-        playerController.movementToggle = false;
-
         return gameState.Value == GameState.GameOver;
     }
 

--- a/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
@@ -150,6 +150,11 @@ public class UIManager : Singleton<UIManager>
         pauseMenu.SetActive(false);
         PauseMenuMultiplayer.SetActive(false);
         GameManager.Instance.isLocalGamePaused = false;
+        PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
+        for (int i = 0; i < playerControllers.Length; i++)
+        {
+            playerControllers[i].movementToggle = true;
+        }
         Time.timeScale = 1f;
     }
 
@@ -308,7 +313,6 @@ public class UIManager : Singleton<UIManager>
             GameManager.Instance.SetLocalPlayerReady();
             closeTutorial.GetComponentInChildren<Text>().text = "Close";
             ReturnToGame();
-            FindObjectOfType<PlayerController>().movementToggle = true;
             return;
         }
         ShowPause();

--- a/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
@@ -308,6 +308,7 @@ public class UIManager : Singleton<UIManager>
             GameManager.Instance.SetLocalPlayerReady();
             closeTutorial.GetComponentInChildren<Text>().text = "Close";
             ReturnToGame();
+            FindObjectOfType<PlayerController>().movementToggle = true;
             return;
         }
         ShowPause();

--- a/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
+++ b/Assets/Development/Scripts/Helpers/Managers/UIManager.cs
@@ -150,11 +150,6 @@ public class UIManager : Singleton<UIManager>
         pauseMenu.SetActive(false);
         PauseMenuMultiplayer.SetActive(false);
         GameManager.Instance.isLocalGamePaused = false;
-        PlayerController[] playerControllers = FindObjectsOfType<PlayerController>();
-        for (int i = 0; i < playerControllers.Length; i++)
-        {
-            playerControllers[i].movementToggle = true;
-        }
         Time.timeScale = 1f;
     }
 

--- a/Assets/Development/Scripts/Player/PlayerController.cs
+++ b/Assets/Development/Scripts/Player/PlayerController.cs
@@ -147,6 +147,8 @@ public class PlayerController : NetworkBehaviour, IIngredientParent, IPickupObje
 
     private void Start()
     {
+        movementToggle = false;
+
         if (IsOwner && SceneManager.GetActiveScene().name == Loader.Scene.T5M3_BUILD.ToString())
         {
             virtualCamera = FindObjectOfType<CinemachineVirtualCamera>();

--- a/Assets/Development/Scripts/UI/CustomerReviewManager.cs
+++ b/Assets/Development/Scripts/UI/CustomerReviewManager.cs
@@ -23,6 +23,7 @@ public class CustomerReviewManager : NetworkBehaviour
     public float rPSpeed;
     public float rPArrivalThreshold;
     public float popOutReviewTime;
+    public bool gameOverBool;
     private bool reviewInProgress;
     private TextMeshProUGUI customerReviewText;
 
@@ -66,10 +67,11 @@ public class CustomerReviewManager : NetworkBehaviour
         OnOneStarCustomerReviewReceived?.Invoke(customer, starAmount);
     }
 
-
-
     public void ShowCustomerReview(CustomerBase customer, float starAmount)
     {
+        if (gameOverBool == true) 
+            return;
+
         if (reviewInProgress == false)
         {
             customerReviewText = customerReview.GetComponentInChildren<TextMeshProUGUI>();


### PR DESCRIPTION
# Related board task URL
https://trello.com/c/mFUmt4CS/674-lock-player-pause-game-activity-when-game-over-screen-is-up-and-before-the-game-starts

# Description of changes
- Players Cannot move until everyone is ready
- Gameover causes all customers to leave, no more will spawn, and player cant move

# Related notes
- 

